### PR TITLE
Add ignore files for build outputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore build outputs
+invaders
+*.exe
+*.o
+
+# Ignore intermediate build directories
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore build outputs
+invaders
+*.exe
+*.o
+
+# Ignore intermediate build directories
+build/


### PR DESCRIPTION
## Summary
- keep build artifacts out of version control via `.gitignore`
- mirror ignore rules for Docker builds in `.dockerignore`

## Testing
- `make` *(fails: allegro5 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f817f02ec8324b976b7995f6ce188